### PR TITLE
Finish usage of new `km_core_state_context_set_if_needed` API and fix warning

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -450,7 +450,7 @@ void fcitx::KeymanEngine::keyEvent(const fcitx::InputMethodEntry &entry,
     FCITX_KEYMAN_DEBUG() << "after process key event context: "
                          << get_current_context_text(context);
 
-    UniqueCPtr<km_core_actions, &km_core_actions_dispose> actions(
+    UniqueCPtr<km_core_actions const, &km_core_actions_dispose> actions(
         km_core_state_get_actions(keyman->state));
 
     auto numOfDelete = actions->code_points_to_delete;
@@ -458,7 +458,7 @@ void fcitx::KeymanEngine::keyEvent(const fcitx::InputMethodEntry &entry,
 
     if (numOfDelete > 0) {
         if (numOfDelete == 1 && keyEvent.key().check(FcitxKey_BackSpace)) {
-            actions->emit_keystroke = KM_CORE_TRUE;
+            emit_keystroke = true;
         } else if (ic->capabilityFlags().test(CapabilityFlag::SurroundingText)) {
             ic->deleteSurroundingText(-numOfDelete, numOfDelete);
             FCITX_KEYMAN_DEBUG()
@@ -491,8 +491,9 @@ void fcitx::KeymanEngine::keyEvent(const fcitx::InputMethodEntry &entry,
     if (!output.empty()) {
         ic->commitString(output);
     }
-    if (actions->emit_keystroke) {
+    if (actions->emit_keystroke || emit_keystroke) {
         FCITX_KEYMAN_DEBUG() << "EMIT_KEYSTROKE action";
+        emit_keystroke = false;
     } else {
         keyEvent.filterAndAccept();
     }

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -432,9 +432,7 @@ void fcitx::KeymanEngine::keyEvent(const fcitx::InputMethodEntry &entry,
     FCITX_KEYMAN_DEBUG() << "after process key event context : "
                          << get_current_context_text_debug(keyman->state);
 
-    UniqueCPtr<km_core_actions const, &km_core_actions_dispose> actions(
-        km_core_state_get_actions(keyman->state));
-
+    km_core_actions const *actions = km_core_state_get_actions(keyman->state);
     auto numOfDelete = actions->code_points_to_delete;
     FCITX_KEYMAN_DEBUG() << "BACK action " << numOfDelete;
 

--- a/src/engine.h
+++ b/src/engine.h
@@ -104,6 +104,7 @@ private:
     KeymanConfig config_;
     std::unique_ptr<HandlerTableEntry<EventHandler>> updateHandler_;
     int64_t timestamp_ = 0;
+    bool emit_keystroke = false;
 };
 
 class KeymanEngineFactory : public AddonFactory {


### PR DESCRIPTION
- While trying to compile the build failed with warnings, so the first commit fixes those warnings.
- Also replace `resetContext` with `updateContext` and `clearContext` to make it clearer what the methods do now.
- remove invalidate context handling since that is now entirely done in Core.
- rename `get_current_context_text` to `get_current_context_text_debug` since that is a debug-only method.

The new Core API completely deals with the context in Core. 

Unfortunately I wasn't able to test these changes since I didn't manage to get fcitx5 to use my compiled fcitx5-keyman.

Note that this PR requires changes in `libkeymancore` that haven't been merged yet and so are not available yet in Keyman 17 alpha ([#10390](https://github.com/keymanapp/keyman/pull/10390)).

Fixes #3.