### PR TITLE
Port keyman support to V18

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ include(ECMUninstallTarget)
 find_package(Gettext REQUIRED)
 find_package(Fcitx5Core ${REQUIRED_FCITX_VERSION} REQUIRED)
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(Keyman REQUIRED IMPORTED_TARGET "keyman_core")
+pkg_check_modules(Keyman REQUIRED IMPORTED_TARGET "keyman_core>=18")
 pkg_check_modules(JsonC REQUIRED IMPORTED_TARGET "json-c")
 
 add_definitions(-DFCITX_GETTEXT_DOMAIN=\"fcitx5-keyman\")

--- a/src/engine.h
+++ b/src/engine.h
@@ -54,7 +54,7 @@ public:
     const auto &metadata() const { return metadata_; }
     auto *kbpKeyboard() const { return keyboard_; }
     const auto &factory() const { return factory_; }
-    void setOption(const km_core_cp *key, const km_core_cp *value);
+    void setOption(const km_core_cu *key, const km_core_cu *value);
 
 private:
     Instance *instance_;


### PR DESCRIPTION
18+ require read keyboard file directly in memory, implement it as mmap
for simplicity and less memory copy.

Fix #7
